### PR TITLE
small changes to make django-iban work in python 3

### DIFF
--- a/django_iban/tests.py
+++ b/django_iban/tests.py
@@ -57,7 +57,7 @@ class IBANTests(TestCase):
 
     def test_date_conditional_iban(self):
         # Test validation for Guatemala after activation date.
-        future_date = datetime.date(2020, 01, 01)
+        future_date = datetime.date(2020, 1, 1)
         iban_validator('GT82TRAJ01020000001210029690', future_date)
 
     def test_iban_fields(self):

--- a/django_iban/validators.py
+++ b/django_iban/validators.py
@@ -99,11 +99,11 @@ def iban_validator(value, future_date=None):
         current_date = timezone.now().date()
 
     # Qatar becomes part of the IBAN system on 1 January 2014.
-    if current_date >= datetime.date(2014, 01, 01):
+    if current_date >= datetime.date(2014, 1, 1):
         iban_length['QA'] = 29
 
     # Guatemala becomes part of the IBAN system on 1 July 2014.
-    if current_date >= datetime.date(2014, 07, 01):
+    if current_date >= datetime.date(2014, 7, 1):
         iban_length['GT'] = 28
 
     # Official validation algorithm:
@@ -152,7 +152,7 @@ def swift_bic_validator(value):
     # First 4 letters are A - Z.
     institution_code = value[:4]
     for x in institution_code:
-        if x not in string.uppercase:
+        if x not in string.ascii_uppercase:
             raise ValidationError(_(u"%s is not a valid SWIFT-BIC Institution Code.") % institution_code)
 
     # Letters 5 and 6 consist of an ISO 3166-1 alpha-2 country code.


### PR DESCRIPTION
changed dates to be date(2014, 2, 2) instead of date(2014, 02, 02)
changed bic/swift validator to use string.ascii_uppercase instead of string.uppercase

in combination with python 3.3.2, django 1.6.2 and django_countries 2.0c1, the tests run without error
